### PR TITLE
set background and colorscheme name

### DIFF
--- a/colors/noctis.lua
+++ b/colors/noctis.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_azureus.lua
+++ b/colors/noctis_azureus.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_azureus'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_bordo.lua
+++ b/colors/noctis_bordo.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_bordo'
+
 colorscheme.from_palette(palette, {
   Type             = { fg=palette.blue,       bold=true },
   Include          = { fg=palette.red,        bold=true },

--- a/colors/noctis_hibernus.lua
+++ b/colors/noctis_hibernus.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'light'
+vim.g.colors_name = 'noctis_hibernus'
+
 colorscheme.from_palette(palette, {
   Type             = { fg=palette.blue,       bold=true },
   Include          = { fg=palette.red,        bold=true },

--- a/colors/noctis_lilac.lua
+++ b/colors/noctis_lilac.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'light'
+vim.g.colors_name = 'noctis_lilac'
+
 colorscheme.from_palette(palette, {
   Type             = { fg=palette.blue,       bold=true },
   Include          = { fg=palette.red,        bold=true },

--- a/colors/noctis_lux.lua
+++ b/colors/noctis_lux.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'light'
+vim.g.colors_name = 'noctis_lux'
+
 colorscheme.from_palette(palette, {
   Type             = { fg=palette.blue,       bold=true },
   Include          = { fg=palette.red,        bold=true },

--- a/colors/noctis_minimus.lua
+++ b/colors/noctis_minimus.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_minimus'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_obscuro.lua
+++ b/colors/noctis_obscuro.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_obscuro'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_sereno.lua
+++ b/colors/noctis_sereno.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_sereno'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_uva.lua
+++ b/colors/noctis_uva.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_uva'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },

--- a/colors/noctis_viola.lua
+++ b/colors/noctis_viola.lua
@@ -24,6 +24,9 @@ local palette = {
   none          = 'NONE',
 };
 
+vim.opt.background = 'dark'
+vim.g.colors_name = 'noctis_viola'
+
 colorscheme.from_palette(palette, {
   Type      = { fg=palette.blue, bold=true },
   Include   = { fg=palette.red, bold=true },


### PR DESCRIPTION
I met an issue when using noctis on gnome terminal. After setting light color theme for gnome terminal, the colors of nvim will be wrong, no matter the light or dark noctis theme is used. Here is the image:
![image](https://github.com/talha-akram/noctis.nvim/assets/13688920/8a523261-8a0c-4798-96f0-35d991226137)

Finally I found the root cause, noctis should set the vim.opt.background before applying the colors. So I opened this pull request to fix it.

the new look is below and it is OK:
![image](https://github.com/talha-akram/noctis.nvim/assets/13688920/8441a428-3311-4655-9e46-4cfc44a8da32)

